### PR TITLE
Bugfix/brand refac

### DIFF
--- a/parser_service/loader/constants.py
+++ b/parser_service/loader/constants.py
@@ -1,13 +1,14 @@
-MAIN_MENU: str = ('https://static-basket-01.wb.ru/vol0/'
-                  'data/main-menu-ru-ru-v2.json')
-BASE_URL: str = 'https://catalog.wb.ru/catalog/'
+MAIN_MENU = ('https://static-basket-01.wb.ru/vol0/'
+             'data/main-menu-ru-ru-v2.json')
+BASE_URL = 'https://catalog.wb.ru/catalog/'
 QUERY_PARAMS = '&appType=1&dest=-1029256,-102269,-1304596,-1281263'
-LAST_PAGE_TRESHOLD: int = 95
-MAX_PAGE: int = 100
-MAX_ITEMS_IN_REQUEST: int = 750
-MAX_ITEMS_IN_BRANDS_FILTER: int = 500
-MAX_BRANDS_IN_REQUEST: int = 20
-MIN_PRICE_RANGE: int = 20000
-ATTEMPTS_COUNTER: int = 10
-REQUEST_LIMIT: int = 200
-WORKER_COUNT: int = 100
+CARD_URL = f'https://card.wb.ru/cards/detail?spp=30{QUERY_PARAMS}&nm='
+LAST_PAGE_TRESHOLD = 95
+MAX_PAGE = 100
+MAX_ITEMS_IN_REQUEST = 750
+MAX_ITEMS_IN_BRANDS_FILTER = 500
+MAX_BRANDS_IN_REQUEST = 20
+MIN_PRICE_RANGE = 20000
+ATTEMPTS_COUNTER = 10
+REQUEST_LIMIT = 200
+WORKER_COUNT = 100

--- a/parser_service/loader/schemas.py
+++ b/parser_service/loader/schemas.py
@@ -56,8 +56,3 @@ class ArticleSchema(BaseModel):
     feedbacks: int
     colors: list[dict]
     sizes: list[dict]
-
-
-class ColorSchema(BaseModel):
-    id: int
-    name: str

--- a/parser_service/logger_config.py
+++ b/parser_service/logger_config.py
@@ -2,7 +2,7 @@ import logging
 from logging.config import dictConfig
 
 
-DEFAULT_LEVEL = "CRITICAL"
+DEFAULT_LEVEL = "INFO"
 
 
 logging_schema = {
@@ -28,8 +28,6 @@ logging_schema = {
             "filename": "parser_log.log",
             "mode": "a",
             "encoding": "utf-8",
-            "maxBytes": 500000,
-            "backupCount": 4
         }
     },
     "loggers": {


### PR DESCRIPTION
Жду комментарии по обновленному _get_items_ids_chunk. Получилась опять немного усложненная логика. Изначальный план: запускать сортировку по цене, и если товаров больше 10000, то идти в обратном направлении, и в таком случае в тот момент, когда встречается уже пройденный итем, останавливать цикл, чтобы избежать проход по уже пройденным итемам в первом направлении.
Но почему-то WB отдает меньше товаров, чем есть на самом деле, когда сортируешь по возрастанию/убыванию цены. Погрешность какая-то есть всегда, но ближе всего к правде получается, когда сортируешь по популярности. Поэтому первоначальный проход - сортировка по популярности, затем при необходимости два доп запуска: по возрастанию/убыванию цены. Из-за особенности написания (рекурсия) я не смог придумать, как останавливать цикл, когда прошел уже по возрастанию и идя по убыванию наткнулся на уже пройденный элемент. Но проблемы не вижу, так как элементы складываются в сет, дубликаты отсеиваются, и на запись в БД идут только уники. Немного больше ресурса тратится на лишние проходы по страницам, но думаю можно пренебречь.